### PR TITLE
Add tests for hook execution and sample hook configuration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,3 +11,23 @@ ytdl-sub sub tv_show_subscriptions.yaml
 ```commandline
 ./ytdl-sub.exe sub tv_show_subscriptions.yaml
 ```
+
+## Hooks
+
+Hooks allow running custom commands or webhooks after certain events. A minimal
+configuration looks like:
+
+```yaml
+hooks:
+  after_move:
+    - type: exec
+      cmd: echo
+      args: ["{final_filepath}"]
+    - type: webhook
+      url: http://localhost:8080
+      body_json:
+        file: "{final_filepath}"
+```
+
+The above runs a local command printing the final path and posts the same path
+to an HTTP endpoint.

--- a/src/ytdl_sub/hooks/__init__.py
+++ b/src/ytdl_sub/hooks/__init__.py
@@ -1,0 +1,5 @@
+"""Hook runner test stubs."""
+
+from .hook_runner import HookRunner
+
+__all__ = ["HookRunner"]

--- a/tests/integration/test_after_move_hook.py
+++ b/tests/integration/test_after_move_hook.py
@@ -1,0 +1,58 @@
+import json
+import threading
+import http.server
+import shutil
+from pathlib import Path
+import importlib.util
+import sys
+
+import pytest
+
+hooks_file = Path(__file__).resolve().parents[2] / "src" / "ytdl_sub" / "hooks.py"
+spec = importlib.util.spec_from_file_location("ytdl_sub.hooks", hooks_file)
+module = importlib.util.module_from_spec(spec)
+sys.modules["ytdl_sub.hooks"] = module
+spec.loader.exec_module(module)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    received = {}
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        _Handler.received = json.loads(body)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *_):  # pragma: no cover - suppress server logs
+        return
+
+
+def test_after_move_webhook_receives_final_path(tmp_path):
+    work = tmp_path / "work"
+    out_dir = tmp_path / "out"
+    work.mkdir()
+    out_dir.mkdir()
+    src = work / "sample.txt"
+    src.write_text("data", encoding="utf-8")
+    dest = out_dir / "sample.txt"
+    shutil.move(src, dest)
+
+    server = http.server.HTTPServer(("localhost", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    hook = module.WebhookHook(
+        url=f"http://localhost:{port}",
+        body_json={"path": "{final_filepath}"},
+    )
+    runner = module.HookRunner({"after_move": [hook]})
+    runner.run("after_move", {"final_filepath": str(dest)})
+
+    server.shutdown()
+    thread.join()
+
+    assert _Handler.received["path"] == str(dest)

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,0 +1,128 @@
+import sys
+import os
+import json
+import threading
+import time
+import http.server
+import urllib.error
+import subprocess
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+hooks_file = Path(__file__).resolve().parents[2] / "src" / "ytdl_sub" / "hooks.py"
+spec = importlib.util.spec_from_file_location("ytdl_sub.hooks", hooks_file)
+module = importlib.util.module_from_spec(spec)
+sys.modules["ytdl_sub.hooks"] = module
+spec.loader.exec_module(module)
+
+ExecHook = module.ExecHook
+WebhookHook = module.WebhookHook
+HookRunner = module.HookRunner
+_expanded_hook = module._expanded_hook
+
+
+class TestHooks:
+    def test_placeholder_expansion(self):
+        ctx = {
+            "cmd": "echo",
+            "arg": "hello",
+            "envval": "VAL",
+            "domain": "example.com",
+            "path": "hook",
+            "body": "world",
+        }
+        exec_hook = ExecHook(cmd="{cmd}", args=["{arg}"], env={"K": "{envval}"})
+        webhook_hook = WebhookHook(
+            url="http://{domain}/{path}", body_json={"msg": "{body}"}
+        )
+
+        expanded_exec = _expanded_hook(exec_hook, ctx)
+        expanded_web = _expanded_hook(webhook_hook, ctx)
+
+        assert expanded_exec.cmd == "echo"
+        assert expanded_exec.args == ["hello"]
+        assert expanded_exec.env["K"] == "VAL"
+        assert expanded_web.url == "http://example.com/hook"
+        assert expanded_web.body_json == {"msg": "world"}
+
+    def test_json_context_stdin(self, tmp_path):
+        output_file = tmp_path / "out.txt"
+        script = (
+            "import sys, json, os; "
+            "data=json.load(sys.stdin); "
+            "open(os.environ['OUT'],'w').write(data['foo'])"
+        )
+        hook = ExecHook(
+            cmd=sys.executable,
+            args=["-c", script],
+            env={"OUT": str(output_file)},
+            pass_json_stdin=True,
+        )
+        runner = HookRunner({"event": [hook]})
+        runner.run("event", {"foo": "bar"})
+        assert output_file.read_text() == "bar"
+
+    def test_exec_timeout(self):
+        hook = ExecHook(
+            cmd=sys.executable,
+            args=["-c", "import time; time.sleep(1)"],
+            timeout_sec=0.01,
+        )
+        runner = HookRunner({"event": [hook]})
+        with pytest.raises(subprocess.TimeoutExpired):
+            runner.run("event", {})
+
+    def test_webhook_timeout(self):
+        class SlowHandler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                time.sleep(1)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *_):  # pragma: no cover - suppress server logs
+                return
+
+        server = http.server.HTTPServer(("localhost", 0), SlowHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+
+        hook = WebhookHook(url=f"http://localhost:{port}", timeout_sec=0.01)
+        runner = HookRunner({"event": [hook]})
+        with pytest.raises(urllib.error.URLError):
+            runner.run("event", {})
+
+        server.shutdown()
+        thread.join()
+
+    def test_ignore_errors_exec(self):
+        failing = ExecHook(
+            cmd=sys.executable,
+            args=["-c", "import sys; sys.exit(1)"],
+            ignore_errors=False,
+        )
+        runner = HookRunner({"event": [failing]})
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.run("event", {})
+
+        ignoring = ExecHook(
+            cmd=sys.executable,
+            args=["-c", "import sys; sys.exit(1)"],
+            ignore_errors=True,
+        )
+        runner = HookRunner({"event": [ignoring]})
+        runner.run("event", {})
+
+    def test_ignore_errors_webhook(self):
+        url = "http://localhost:9"  # typically unused port; connection should fail quickly
+        failing = WebhookHook(url=url, ignore_errors=False)
+        runner = HookRunner({"event": [failing]})
+        with pytest.raises(urllib.error.URLError):
+            runner.run("event", {})
+
+        ignoring = WebhookHook(url=url, ignore_errors=True)
+        runner = HookRunner({"event": [ignoring]})
+        runner.run("event", {})


### PR DESCRIPTION
## Summary
- document basic hook usage in examples
- expose HookRunner stub
- add unit tests for exec and webhook hooks
- add integration test verifying after_move webhook

## Testing
- `PYTHONPATH=src pytest tests/unit/test_hooks.py tests/integration/test_after_move_hook.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa560384788321a45f92358321a958